### PR TITLE
Update pbench-fio.wrapper to remove 'continue'

### DIFF
--- a/pbench_runner/pbench-fio/pbench-fio.wrapper
+++ b/pbench_runner/pbench-fio/pbench-fio.wrapper
@@ -23,12 +23,12 @@ for arg in $@; do
 
     if [[ "$arg" =~ ^--block-sizes= ]]; then
         bs_tag=$(echo $arg | cut -d= -f2 | tr ',' '_')
-        continue
+        # continue
     fi
 
     if [[ "$arg" =~ ^--test-types= ]]; then
         rw_tag=$(echo $arg | cut -d= -f2 | tr ',' '_')
-        continue
+        # continue
     fi
 
     # append non-processed args


### PR DESCRIPTION
Currently only read and randread type, even add the write parameter, which has been ignored to append the args.