### PR TITLE
Update pbench-uperf-runner.py

### DIFF
--- a/pbench_runner/pbench-uperf/pbench-uperf-runner.py
+++ b/pbench_runner/pbench-uperf/pbench-uperf-runner.py
@@ -75,7 +75,7 @@ def test_suites(test_suite_name):
         test_types = "stream,maerts,rr,bidirec"
         instances = "1"
         runtime = 10
-        message_sizes = "1,64"
+        message_sizes = "64,1024"
         nr_samples = 3
         max_failures = 3
         maxstddevpct = 5
@@ -85,7 +85,7 @@ def test_suites(test_suite_name):
         test_types = "stream,maerts,rr,bidirec"
         instances = "1,8"
         runtime = 20
-        message_sizes = "1,64,1024"
+        message_sizes = "64,1024,10240"
         nr_samples = 3
         max_failures = 3
         maxstddevpct = 5
@@ -94,8 +94,8 @@ def test_suites(test_suite_name):
         protocols = "tcp,udp"
         test_types = "stream,maerts,rr,bidirec"
         instances = "1,8,64"
-        runtime = 60
-        message_sizes = "1,64,1024,16384"
+        runtime = 30
+        message_sizes = "64,1024,10240,102400"
         nr_samples = 5
         max_failures = 6
         maxstddevpct = 5


### PR DESCRIPTION
Remove message size as 1 byte, which cannot reach throughoutput when do quick test, add 1024 bytes to quick, standard test.

The recommended message size for uperf can depend on several factors such as the network bandwidth, latency, and the specific goals of your performance test. However, a common approach is to test with various message sizes to understand how network performance varies under different conditions. Here are some guidelines for selecting message sizes when using uperf: Small Message Sizes:
Start with small message sizes (e.g., 64 bytes) to measure the overhead of sending small packets and to evaluate latency performance.

Medium Message Sizes:
Test with medium-sized messages (e.g., 1 KB to 10 KB) to evaluate the throughput of the network, as well as the efficiency of network utilization.

Large Message Sizes:
Test with large message sizes (e.g., 100 KB to 1 MB) to assess the ability of the network to handle bulk data transfers and to detect potential bottlenecks in the network infrastructure.